### PR TITLE
alternative defaults: `.env.defaults`

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,18 @@ Since multiple `.env*` files are loaded together at the same time, all the varia
 5) if any variables are already defined in the environment before reading from `.env*`, they will not be overwritten, thus having the higher priority over defined in any env file;
 
 
+## Alternative defaults: `.env.defaults` 
+
+In addition to `.env`, you may also use `.env.defaults` to store default (fallback) values.
+
+This may come handy e.g. when migrating from [dotenv](https://github.com/motdotla/dotenv) (where it is strongly advised against committing `.env` file to VCS)
+and you already have `.env` file used to store your local values.
+
+In such case, you may prefer to keep using your existing `.env` (**ignored** by VCS) as your local config
+and create additional `.env.defaults` (**tracked** by VCS) file which will be loaded before `.env`. 
+
+Then at every place `.env` is mentioned in the docs, read it as: "`.env.defaults` first, then `.env`".
+
 ## `dotenv-flow/config` options
 
 When preloading **dotenv-flow** using the node's `-r` switch you can use the following configuration options:

--- a/lib/dotenv-flow.js
+++ b/lib/dotenv-flow.js
@@ -19,6 +19,7 @@ function listDotenvFiles(dirname, options = {}) {
   const {node_env} = options;
 
   return [
+    resolve(dirname, '.env.defaults'),
     resolve(dirname, '.env'),
     (node_env !== 'test') && resolve(dirname, '.env.local'),
     node_env && resolve(dirname, `.env.${node_env}`),

--- a/test/integration/fixtures/env-defaults/.env
+++ b/test/integration/fixtures/env-defaults/.env
@@ -1,0 +1,2 @@
+ENV_VAR=ok
+ENV_ONLY_VAR=ok

--- a/test/integration/fixtures/env-defaults/.env.defaults
+++ b/test/integration/fixtures/env-defaults/.env.defaults
@@ -1,0 +1,2 @@
+DEFAULT_ENV_VAR=ok
+ENV_VAR=should be overwritten by `.env`

--- a/test/unit/dotenv-flow-api.spec.js
+++ b/test/unit/dotenv-flow-api.spec.js
@@ -34,6 +34,11 @@ describe('dotenv-flow (API)', () => {
           .map(p => normalizePosixPath(p));
       });
 
+      it('lists the default `.env.defaults` file', () => {
+        expect(filenames)
+          .to.include('/path/to/project/.env.defaults');
+      });
+
       it('lists the default `.env` file', () => {
         expect(filenames)
           .to.include('/path/to/project/.env');
@@ -47,6 +52,7 @@ describe('dotenv-flow (API)', () => {
       it('lists `.env*` files in the "variables overwriting" order', () => {
         expect(filenames)
           .to.have.ordered.members([
+            "/path/to/project/.env.defaults",
             '/path/to/project/.env',
             '/path/to/project/.env.local'
           ]);
@@ -84,6 +90,7 @@ describe('dotenv-flow (API)', () => {
       it('lists `.env*` files in the "variables overwriting" order', () => {
         expect(filenames)
           .to.have.ordered.members([
+            '/path/to/project/.env.defaults',
             '/path/to/project/.env',
             '/path/to/project/.env.local',
             '/path/to/project/.env.development',
@@ -403,7 +410,7 @@ describe('dotenv-flow (API)', () => {
 
         // path.resolve() calls process.cwd() internally on windows
         // https://github.com/nodejs/node/blob/d0377a825bf7ceb838570f434fdd7d4b1773b8fa/lib/path.js#L146
-        // listDotenvFiles calls path.resolve() 2 times, so $processCwd.callCount === 3 on win (and 1 on posix)
+        // listDotenvFiles calls path.resolve() 3 times, so $processCwd.callCount === 4 on win (and 1 on posix)
         if (!isWindows()) {
           expect($processCwd)
             .to.have.been.calledOnce;
@@ -628,7 +635,7 @@ describe('dotenv-flow (API)', () => {
 
         // path.resolve() calls process.cwd() internally on windows
         // https://github.com/nodejs/node/blob/d0377a825bf7ceb838570f434fdd7d4b1773b8fa/lib/path.js#L146
-        // listDotenvFiles calls path.resolve() 2 times, so $processCwd.callCount === 2 on win (and 0 on posix)
+        // listDotenvFiles calls path.resolve() 3 times, so $processCwd.callCount === 3 on win (and 0 on posix)
         if (!isWindows()) {
           expect($processCwd)
             .to.have.not.been.called;


### PR DESCRIPTION
I have a use case where I can't use `.env` file as defaults easily, without intricate measures, transition periods, automated scripts migrating `.env` to `.env.local` etc. (migrating from `dotenv` on a shared repo with multiple devs constantly working on it)

I can expect that it might be difficult to convince you to add this feature, I tried to explain the reasoning, but I am not too good at writing docs - so if you find this useful, any suggestions how to describe it better would be very welcome...


Below is the new paragraph from README:

---

## Alternative defaults: `.env.defaults` 

In addition to `.env`, you may also use `.env.defaults` to store default (fallback) values.

This may come handy e.g. when migrating from [dotenv](https://github.com/motdotla/dotenv) (where it is strongly advised against committing `.env` file to VCS)
and you already have `.env` file used to store your local values.

In such case, you may prefer to keep using your existing `.env` (**ignored** by VCS) as your local config
and create additional `.env.defaults` (**tracked** by VCS) file which will be loaded before `.env`. 

Then at every place `.env` is mentioned in the docs, read it as: "`.env.defaults` first, then `.env`".