### PR TITLE
typescript declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lib/cli-options.js",
     "config.js"
   ],
+  "types": "types/index.d.ts",
   "dependencies": {
     "dotenv": "^8.0.0"
   },

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -121,6 +121,17 @@ export function load(
   options?: DotenvLoadOptions
 ): DotenvLoadOutput;
 
+/**
+ * Unload variables defined in a given file(s) from `process.env`.
+ *
+ * This function can gracefully resolve the following issue:
+ *
+ * In some cases the original "dotenv" library can be used by one of the dependent npm modules.
+ * It causes calling the original `dotenv.config()` that loads the `.env` file from your project before you can call `dotenv-flow.config()`.
+ * Such cases breaks `.env*` files priority because the previously loaded environment variables are treated as shell-defined thus having a higher priority.
+ *
+ * Unloading the previously loaded `.env` file can be activated when using the `dotenv-flow.config()` with the `purge_dotenv` option set to `true`.
+ */
 export function unload(
   filenames: DotenvFilenames,
   options?: ReadFileSyncOptions

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,9 +5,9 @@ import { readFileSync } from 'fs';
 
 export type ReadFileSyncOptions = Parameters<typeof readFileSync>[1];
 
-export type DotenvFlowFilenames = string | Buffer | Array<string | Buffer>;
+export type DotenvFilenames = string | Buffer | Array<string | Buffer>;
 
-export interface DotenvFlowParseOutput {
+export interface DotenvParseOutput {
   [name: string]: string;
 }
 
@@ -17,11 +17,11 @@ export interface DotenvFlowParseOutput {
  * When several filenames are given, the parsed environment variables are merged using the "overwrite" strategy.
  */
 export function parse(
-  filenames: DotenvFlowFilenames,
+  filenames: DotenvFilenames,
   options?: ReadFileSyncOptions
-): DotenvFlowParseOutput;
+): DotenvParseOutput;
 
-export interface DotenvFlowConfigOptions {
+export interface DotenvConfigOptions {
   /**
    * Node environment (development/test/production/etc,.)
    *
@@ -63,19 +63,19 @@ export interface DotenvFlowConfigOptions {
   silent?: boolean;
 }
 
-export interface DotenvFlowConfigOutput {
+export interface DotenvConfigOutput {
   error?: Error;
-  parsed?: DotenvFlowParseOutput;
+  parsed?: DotenvParseOutput;
 }
 
 /**
  * Loads and parses the contents of your .env* files, merges the results and appends to process.env.*.
  */
 export function config(
-  options?: DotenvFlowConfigOptions
-): DotenvFlowConfigOutput;
+  options?: DotenvConfigOptions
+): DotenvConfigOutput;
 
-export interface DotenvFlowListDotenvFilesOptions {
+export interface DotenvListDotenvFilesOptions {
   /**
    * Node environment (development/test/production/etc,.)
    */
@@ -90,10 +90,10 @@ export interface DotenvFlowListDotenvFilesOptions {
  */
 export function listDotenvFiles(
   dirname: string,
-  options?: DotenvFlowListDotenvFilesOptions
+  options?: DotenvListDotenvFilesOptions
 ): string[];
 
-export interface DotenvFlowLoadOptions {
+export interface DotenvLoadOptions {
   /**
    * Encoding of `.env*` files
    */
@@ -107,7 +107,7 @@ export interface DotenvFlowLoadOptions {
   silent?: boolean;
 }
 
-export type DotenvFlowLoadOutput = DotenvFlowConfigOutput;
+export type DotenvLoadOutput = DotenvConfigOutput;
 
 /**
  * Load variables defined in a given file(s) into `process.env`.
@@ -117,11 +117,11 @@ export type DotenvFlowLoadOutput = DotenvFlowConfigOutput;
  * thus giving a higher priority to the environment variables predefined by the shell.
  */
 export function load(
-  filenames: DotenvFlowFilenames,
-  options?: DotenvFlowLoadOptions
-): DotenvFlowLoadOutput;
+  filenames: DotenvFilenames,
+  options?: DotenvLoadOptions
+): DotenvLoadOutput;
 
 export function unload(
-  filenames: DotenvFlowFilenames,
+  filenames: DotenvFilenames,
   options?: ReadFileSyncOptions
 ): void;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,127 @@
+/// <reference types="node" />
+// Minimum TypeScript Version: 3.1
+
+import { readFileSync } from 'fs';
+
+export type ReadFileSyncOptions = Parameters<typeof readFileSync>[1];
+
+export type DotenvFlowFilenames = string | Buffer | Array<string | Buffer>;
+
+export interface DotenvFlowParseOutput {
+  [name: string]: string;
+}
+
+/**
+ * Parse a given file(s) to use the result programmatically.
+ *
+ * When several filenames are given, the parsed environment variables are merged using the "overwrite" strategy.
+ */
+export function parse(
+  filenames: DotenvFlowFilenames,
+  options?: ReadFileSyncOptions
+): DotenvFlowParseOutput;
+
+export interface DotenvFlowConfigOptions {
+  /**
+   * Node environment (development/test/production/etc,.)
+   *
+   * @default process.env.NODE_ENV
+   */
+  node_env?: string;
+
+  /**
+   * The default node environment
+   */
+  default_node_env?: string;
+
+  /**
+   * Path to `.env*` files directory
+   *
+   * @default process.cwd()
+   */
+  path?: string;
+
+  /**
+   * Encoding of `.env*` files
+   *
+   * @default 'utf8'
+   */
+  encoding?: string;
+
+  /**
+   * Perform the `.env` file "unload"
+   *
+   * @default false
+   */
+  purge_dotenv?: boolean;
+
+  /**
+   * Suppress all the console outputs except errors and deprecations
+   *
+   * @default false
+   */
+  silent?: boolean;
+}
+
+export interface DotenvFlowConfigOutput {
+  error?: Error;
+  parsed?: DotenvFlowParseOutput;
+}
+
+/**
+ * Loads and parses the contents of your .env* files, merges the results and appends to process.env.*.
+ */
+export function config(
+  options?: DotenvFlowConfigOptions
+): DotenvFlowConfigOutput;
+
+export interface DotenvFlowListDotenvFilesOptions {
+  /**
+   * Node environment (development/test/production/etc,.)
+   */
+  node_env?: string;
+}
+
+/**
+ * Returns a list of `.env*` filenames ordered by the env files priority from lowest to highest.
+ *
+ * Also, make a note that the `.env.local` file is not included when the value of `node_env` is `"test"`,
+ * since normally you expect tests to produce the same results for everyone.
+ */
+export function listDotenvFiles(
+  dirname: string,
+  options?: DotenvFlowListDotenvFilesOptions
+): string[];
+
+export interface DotenvFlowLoadOptions {
+  /**
+   * Encoding of `.env*` files
+   */
+  encoding?: string;
+
+  /**
+   * Suppress all the console outputs except errors and deprecations
+   *
+   * @default false
+   */
+  silent?: boolean;
+}
+
+export type DotenvFlowLoadOutput = DotenvFlowConfigOutput;
+
+/**
+ * Load variables defined in a given file(s) into `process.env`.
+ *
+ * When several filenames are given, parsed environment variables are merged using the "overwrite" strategy since it utilizes `.parse()` for doing this.
+ * But eventually, assigning the resulting environment variables to `process.env` is done using the "append" strategy,
+ * thus giving a higher priority to the environment variables predefined by the shell.
+ */
+export function load(
+  filenames: DotenvFlowFilenames,
+  options?: DotenvFlowLoadOptions
+): DotenvFlowLoadOutput;
+
+export function unload(
+  filenames: DotenvFlowFilenames,
+  options?: ReadFileSyncOptions
+): void;


### PR DESCRIPTION
allow usage in typescript
```typescript
import dotenv from 'dotenv-flow';
```
without `TS2307: Cannot find module 'dotenv-flow' or its corresponding type declarations.` error.