### PR TITLE
Support for yaml & json

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ When preloading **dotenv-flow** using the node's `-r` switch you can use the fol
 * `DOTENV_FLOW_ENCODING` => [`options.encoding`](#optionsencoding);
 * `DOTENV_FLOW_PURGE_DOTENV` => [`options.purge_dotenv`](#optionspurge_dotenv);
 * `DOTENV_FLOW_SILENT` => [`options.silent`](#optionssilent);
+* `DOTENV_FLOW_SCHEMA` => [`options.schema`](#optionsschema);
 
 ```sh
 $ NODE_ENV=production DOTENV_FLOW_PATH=/path/to/env-files-dir node -r dotenv-flow/config your_script.js
@@ -284,6 +285,7 @@ $ NODE_ENV=production DOTENV_FLOW_PATH=/path/to/env-files-dir node -r dotenv-flo
 * `--dotenv-flow-encoding` => [`options.encoding`](#optionsencoding);
 * `--dotenv-flow-purge-dotenv` => [`options.purge_dotenv`](#optionspurge_dotenv);
 * `--dotenv-flow-silent` => [`options.silent`](#optionssilent);
+* `--dotenv-flow-schema` => [`options.schema`](#optionsschema);
 
 Don't forget to separate **dotenv-flow/config**-specific CLI switches with `--` because they are not recognized by **Node.js**:
 
@@ -406,6 +408,17 @@ require('dotenv-flow').config({
 });
 ```
 
+##### `options.schema`
+###### Type: `string`
+###### Default: `properties`
+
+With this option you can specify the schema of your *.env files (properties, json, yaml). 
+
+```js
+require('dotenv-flow').config({
+  schema: 'json'
+});
+```
 ---
 
 The following API considered as internal, but it is also exposed to give the ability to be used programmatically by your own needs.
@@ -535,6 +548,12 @@ An optional encoding for reading files.
 ###### Default: `false`
 
 Suppress all the console outputs except errors and deprecation warnings.
+
+##### `[options.schema]`
+###### Type: `string`
+###### Default: `properties`
+
+With this option you can specify the schema of your *.env files (properties, json, yaml). 
 
 ##### Returns:
 

--- a/lib/cli-options.js
+++ b/lib/cli-options.js
@@ -6,7 +6,8 @@ const CLI_OPTIONS_MAP = {
   '--dotenv-flow-path': 'path',
   '--dotenv-flow-encoding': 'encoding',
   '--dotenv-flow-purge-dotenv': 'purge_dotenv',
-  '--dotenv-flow-silent': 'silent'
+  '--dotenv-flow-silent': 'silent',
+  '--dotenv-flow-schema': 'schema'
 };
 
 const CLI_OPTION_KEYS = Object.keys(CLI_OPTIONS_MAP);

--- a/lib/dotenv-flow.js
+++ b/lib/dotenv-flow.js
@@ -3,6 +3,7 @@
 const fs = require('fs');
 const {resolve} = require('path');
 const dotenv = require('dotenv');
+const yaml = require('js-yaml');
 
 /**
  * Returns a list of `.env*` filenames ordered by the env files priority from lowest to highest.
@@ -37,14 +38,18 @@ function listDotenvFiles(dirname, options = {}) {
  * @param {object} [options] - `fs.readFileSync` options
  * @return {object} the resulting map of `{ env_var: value }` as an object
  */
-function parse(filenames, options = {}) {
-  if (typeof filenames === 'string') {
-    return dotenv.parse(fs.readFileSync(filenames, options));
-  }
+function parse(filenamesArg, options = {}) {
 
-  return filenames.reduce((parsed, filename) => {
-    return Object.assign(parsed, dotenv.parse(fs.readFileSync(filename, options)));
-  }, {});
+  function parseFile(filename, schema = 'properties') {
+    const envFileContent = fs.readFileSync(filename, options);
+    if (schema === 'properties') {
+      return dotenv.parse(envFileContent);
+    }
+    return yaml.safeLoad(envFileContent, {'schema': options.schema === 'yaml'? yaml.DEFAULT_SAFE_SCHEMA: yaml.JSON_SCHEMA});
+  }
+  const filenames = typeof(filenamesArg) === 'string'? [filenamesArg] : filenamesArg;
+
+  return filenames.reduce((parsed, filename) => Object.assign(parsed, parseFile(filename, options.schema)), {});
 }
 
 /**
@@ -58,12 +63,14 @@ function parse(filenames, options = {}) {
  * @param {object} [options] - file loading options
  * @param {string} [options.encoding="utf8"] - encoding of `.env*` files
  * @param {boolean} [options.silent=false] - suppress all the console outputs except errors and deprecations
+ * @param {string} [options.schema="properties"] - schema of `.env.*` files (properties, yaml, json)
  * @return {object} with a `parsed` key containing the loaded content or an `error` key with an error that is occurred
  */
 function load(filenames, options = {}) {
   try {
     const parsed = parse(filenames, {
-      encoding: options.encoding
+      encoding: options.encoding,
+      schema: options.schema ?? 'properties'
     });
 
     Object.keys(parsed).forEach((key) => {
@@ -116,10 +123,18 @@ function unload(filenames, options = {}) {
  * @param {string} [options.encoding="utf8"] - encoding of `.env*` files
  * @param {boolean} [options.purge_dotenv=false] - perform the `.env` file {@link unload}
  * @param {boolean} [options.silent=false] - suppress all the console outputs except errors and deprecations
+ * @param {string} [options.schema="prop"] - format of `.env*` files (prop, schema)
  * @return {{ parsed?: object, error?: Error }} with a `parsed` key containing the loaded content or an `error` key with an error that is occurred
  */
 function config(options = {}) {
   const node_env = options.node_env || process.env.NODE_ENV || options.default_node_env;
+
+  if (options.schema){
+    const schemaValues = ['properties', 'yaml', 'json'];
+    if (!schemaValues.includes(options.schema)){
+      throw('dotenv-flow: invalid value specified for option schema. Possible values are `properties` (default), `yaml`, or `json`.')
+    }
+  }
 
   let path;
   if (options.path) {
@@ -135,7 +150,8 @@ function config(options = {}) {
 
   const {
     encoding = undefined,
-    silent = false
+    silent = false,
+    format = 'prop'
   } = options;
 
   try {
@@ -148,7 +164,7 @@ function config(options = {}) {
         .filter(filename => fs.existsSync(filename))
     );
 
-    return load(existingFiles, { encoding, silent });
+    return load(existingFiles, { encoding, silent, format });
   }
   catch (error) {
     return { error };

--- a/lib/dotenv-flow.js
+++ b/lib/dotenv-flow.js
@@ -151,7 +151,7 @@ function config(options = {}) {
   const {
     encoding = undefined,
     silent = false,
-    format = 'prop'
+    schema = 'properties'
   } = options;
 
   try {
@@ -164,7 +164,7 @@ function config(options = {}) {
         .filter(filename => fs.existsSync(filename))
     );
 
-    return load(existingFiles, { encoding, silent, format });
+    return load(existingFiles, { encoding, silent, schema });
   }
   catch (error) {
     return { error };

--- a/lib/env-options.js
+++ b/lib/env-options.js
@@ -6,7 +6,8 @@ const ENV_OPTIONS_MAP = {
   DOTENV_FLOW_PATH: 'path',
   DOTENV_FLOW_ENCODING: 'encoding',
   DOTENV_FLOW_PURGE_DOTENV: 'purge_dotenv',
-  DOTENV_FLOW_SILENT: 'silent'
+  DOTENV_FLOW_SILENT: 'silent',
+  DOTENV_FLOW_SCHEMA: 'schema'
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "config.js"
   ],
   "dependencies": {
-    "dotenv": "^8.2.0"
+    "dotenv": "^8.2.0",
+    "js-yaml": "^3.14.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/test/unit/dotenv-flow-api.spec.js
+++ b/test/unit/dotenv-flow-api.spec.js
@@ -272,6 +272,46 @@ describe('dotenv-flow (API)', () => {
           .to.have.not.been.called;
       });
 
+      it('testing yaml as schema for *.env file', () => {
+        $readFileSync
+          .withArgs('/path/to/project/.env')
+          .returns(
+            'foo: bar\n'+
+            'foos: ["bar1", "bar2"]\n' +
+            'foos2:\n' +
+            '  - bar3\n'+
+            '  - bar4\n'
+          );
+        const result = dotenvFlow.load('/path/to/project/.env', { schema: 'yaml' });
+        expect(result)
+          .to.be.an('object')
+          .with.property('parsed')
+          .that.deep.equals({
+          foo: 'bar',
+          foos: ['bar1', 'bar2'],
+          foos2: ['bar3', 'bar4']
+        });
+      });
+
+      it('testing json as schema for *.env file', () => {
+        const json = {
+          foo: 'bar',
+          foos: ['bar1', 'bar2'],
+          foos2: ['bar3', 'bar4']
+        };
+        $readFileSync
+          .withArgs('/path/to/project/.env')
+          .returns(
+            JSON.stringify(json)
+          );
+        const result = dotenvFlow.load('/path/to/project/.env', { schema: 'json' });
+
+        expect(result)
+          .to.be.an('object')
+          .with.property('parsed')
+          .that.deep.equals(json);
+      });
+
       it('returns the parsed content of the file in the `parsed` property', () => {
         const result = dotenvFlow.load('/path/to/project/.env');
 

--- a/test/unit/dotenv-flow-api.spec.js
+++ b/test/unit/dotenv-flow-api.spec.js
@@ -695,7 +695,7 @@ describe('dotenv-flow (API)', () => {
         });
 
         expect($readFileSync)
-          .to.have.been.calledWith(normalize('/path/to/project/.env'), { encoding: 'base64' });
+          .to.have.been.calledWith(normalize('/path/to/project/.env'), { encoding: 'base64', schema: 'properties' });
       });
     });
 
@@ -737,7 +737,7 @@ describe('dotenv-flow (API)', () => {
             .to.have.been.calledWith(normalize('/path/to/project/.env'), { encoding: 'base64' });
 
           expect($readFileSync.secondCall)
-            .to.have.been.calledWith(normalize('/path/to/project/.env'), { encoding: 'base64' });
+            .to.have.been.calledWith(normalize('/path/to/project/.env'), { encoding: 'base64', schema: 'properties'  });
         });
       });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -855,9 +855,9 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
-js-schema@3.13.1:
+js-yaml@3.13.1:
   version "3.13.1"
-  resolved "https://registry.yarnpkg.com/js-schema/-/js-schema-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
   dependencies:
     argparse "^1.0.7"
@@ -1068,7 +1068,7 @@ mocha@7.2.0:
     glob "7.1.3"
     growl "1.10.5"
     he "1.2.0"
-    js-schema "3.13.1"
+    js-yaml "3.13.1"
     log-symbols "3.0.0"
     minimatch "3.0.4"
     mkdirp "0.5.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -863,6 +863,14 @@ js-yaml@3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@^3.14.0:
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz#a7a34170f26a21bb162424d8adacb4113a69e482"
+  integrity sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 json-parse-better-errors@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -855,9 +855,9 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
-js-yaml@3.13.1:
+js-schema@3.13.1:
   version "3.13.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  resolved "https://registry.yarnpkg.com/js-schema/-/js-schema-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
   dependencies:
     argparse "^1.0.7"
@@ -1068,7 +1068,7 @@ mocha@7.2.0:
     glob "7.1.3"
     growl "1.10.5"
     he "1.2.0"
-    js-yaml "3.13.1"
+    js-schema "3.13.1"
     log-symbols "3.0.0"
     minimatch "3.0.4"
     mkdirp "0.5.5"


### PR DESCRIPTION
Hi Dan, I really like dotenv-flow package, but I was missing a prettier style for more complex configurations. So I added support for json and yaml schema for .env.* files. The default schema is 'properties' (works as the origin of this fork). If you like it, feel free to pull :)