### PR TITLE
Document in the variable loading order that `.env.local` is not loaded when `NODE_ENV=test`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Here is an example of the `.gitignore` (or `.hgignore`) file entry to keep it cl
 Since multiple `.env*` files are loaded simultaneously, all the variables defined in these files are merged in the following order:
 
 1) The `.env` file has the lowest priority. _Keep the most default (fallback) values there_;
-2) The `.env.local` file has a priority over the `.env`. _Create it if you want to overwrite the default values for your own environment-specific needs_;
+2) The `.env.local` file has a priority over the `.env` (except when `NODE_ENV=test`, in which case this file is not loaded). _Create it if you want to overwrite the default values for your own environment-specific needs_;
 3) `NODE_ENV`-specific env files (like `.env.development`, `.env.test`, etc.) have a priority over the default `.env` and `.env.local` files. _Keep `NODE_ENV`-specific environment variables there_;
 4) `NODE_ENV`-specific local env files (`.env.development.local`, `.env.production.local`, etc.) have the highest priority over all the env files. _As with `.env.local`, create them only if you need to overwrite `NODE_ENV`-specific values for your own environment-specific needs_;
 5) Environment variables that are already set will not be overwritten, that means that the command line variables have a higher priority over all those defined in env files;


### PR DESCRIPTION
I spent too much time than I would like to admit scratching my head to figure out why `.env.local` is not loaded during testing. It finally dawned on me when I started putting `console.log` statements into `node_modules/dotenv-flow/lib/dotenv-flow.js` and found this:

![image](https://user-images.githubusercontent.com/193136/150765754-67b00683-3e68-406c-bd8d-6a27895828cd.png)

p.s. in creating this PR, I am aware that this has been documented already; I am putting it in a more obvious place, so I can notice it during my first scanthrough of the docs. Currently this behavior is only documented in the "Internal APIs" section (so during my first readthrough I assume that the section wasn't relevant to my problem). Therefore I added documentation in the **Variables overwriting/priority** section which can be found earlier.

## Before

![image](https://user-images.githubusercontent.com/193136/150766288-07a0cfab-4b80-4d8b-982c-b55387f57a1a.png)

## After

![image](https://user-images.githubusercontent.com/193136/150766766-f46a8402-120c-4100-8e1c-a1de0d211f3b.png)
