### PR TITLE
feat: allow setting DOTENV_FLOW_SILENT without preregister

### DIFF
--- a/lib/dotenv-flow.js
+++ b/lib/dotenv-flow.js
@@ -135,7 +135,7 @@ function config(options = {}) {
 
   const {
     encoding = undefined,
-    silent = false
+    silent = Boolean(process.env.DOTENV_FLOW_SILENT) || false
   } = options;
 
   try {


### PR DESCRIPTION
This PR addresses some of the confusion surrounding `DOTENV_FLOW_SILENT`, as discussed in #52, allowing users to set the environment variable and register in code instead of at run.


```javascript
process.env.DOTENV_FLOW_SILENT = 'silent';

require('dotenv-flow/config');
```

```typescript
process.env.DOTENV_FLOW_SILENT = 'silent';

import "dotenv-flow/config";
```

Merge or close, no hard feelings either way. Thanks for the lib.
