### PR TITLE
added `skipLocalOverride` config

### DIFF
--- a/lib/dotenv-flow.js
+++ b/lib/dotenv-flow.js
@@ -7,21 +7,26 @@ const dotenv = require('dotenv');
 /**
  * Returns a list of `.env*` filenames ordered by the env files priority from lowest to highest.
  *
- * Also, make a note that the `.env.local` file is not included when the value of `node_env` is `"test"`,
- * since normally you expect tests to produce the same results for everyone.
- *
  * @param {string} dirname - path to `.env*` files' directory
  * @param {object} [options] - `.env*` files listing options
  * @param {string} [options.node_env] - node environment (development/test/production/etc,.)
+ * @param {boolean | undefined} [options.skipLocalOverride] - skip reading .env.local
  * @return {string[]}
  */
 function listDotenvFiles(dirname, options = {}) {
   const {node_env} = options;
+  let {skipLocalOverride} = options;
+
+  if (skipLocalOverride === undefined && node_env === 'test') {
+    // backwards compatibility, dont include .env.local` file when the value of `node_env`
+    // is `"test"` and skipOverride option is not provided,
+    skipLocalOverride = true
+  }
 
   return [
     resolve(dirname, '.env.defaults'),
     resolve(dirname, '.env'),
-    (node_env !== 'test') && resolve(dirname, '.env.local'),
+    skipLocalOverride && resolve(dirname, '.env.local'),
     node_env && resolve(dirname, `.env.${node_env}`),
     node_env && resolve(dirname, `.env.${node_env}.local`)
   ]


### PR DESCRIPTION
We have a use case where we *dont* want to skip reading the `.env.local` file when node_env = "test" but another environment value. All in all, the way this was set up seems rather inflexible, having "test" hard coded here.

So I propose to have a `skipLocalOverride` boolean config option. For backwards compatibility, when left `undefined` we will still check if `node_env` = "test". But if you provide it with a value of `false`, it will not skip reading the `.env.local`.

We intend to use it like this: 

`
DotEnv.config({
  path: './../../../',
  skipLocalOverride: process.env.NODE_ENV === 'ENV-THAT-WE-DONT-WANT-TO-LOAD-LOCALOVERRIDE-ON'
})
`