### PR TITLE
feat(dotenv-flow): return error if none of the `.env*` files is found

### DIFF
--- a/lib/dotenv-flow.js
+++ b/lib/dotenv-flow.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const fs = require('fs');
-const {resolve} = require('path');
+const {resolve, sep} = require('path');
 const dotenv = require('dotenv');
 
 /**
@@ -161,6 +161,14 @@ function config(options = {}) {
       listFiles(path, { node_env })
         .filter(filename => fs.existsSync(filename))
     );
+
+    if (existingFiles.length === 0) {
+      const message = node_env
+          ? `no ".env*" files matching pattern "${path + sep}.env[.${node_env}][.local]"`
+          : `no ".env*" files matching pattern "${path + sep}.env[.local]" (no \`process.env.NODE_ENV\` or \`options.default_node_env\` is defined)`;
+
+      return { error: new Error(message) };
+    }
 
     return load(existingFiles, { encoding, silent });
   }


### PR DESCRIPTION
With this change dotenv-flow's `.config()` method will start returning an error if none of the appropriate ".env*" files is found.

Closes #41.