### PR TITLE
feat(dotenv-flow): add `options.pattern` for customizing `.env*` files' naming convention, closes #8

### DIFF
--- a/lib/dotenv-flow.js
+++ b/lib/dotenv-flow.js
@@ -4,28 +4,85 @@ const fs = require('fs');
 const {resolve, sep} = require('path');
 const dotenv = require('dotenv');
 
+const DEFAULT_PATTERN = '.env[.node_env][.local]';
+
+const LOCAL_PLACEHOLDER_REGEX = /\[(\W*\blocal\b\W*)]/g;
+const NODE_ENV_PLACEHOLDER_REGEX = /\[(\W*\b)node_env(\b\W*)]/g;
+
 /**
- * Returns a list of `.env*` filenames ordered by the env files priority from lowest to highest.
+ * Compose a filename from a given `patten`.
  *
- * Also, make a note that the `.env.local` file is not included when the value of `node_env` is `"test"`,
+ * @param {string} pattern
+ * @param {object} [options]
+ * @param {boolean} [options.local]
+ * @param {string} [options.node_env]
+ * @return {string} filename
+ */
+function composeFilename(pattern, options) {
+  let filename = pattern;
+
+  filename = filename.replace(
+    LOCAL_PLACEHOLDER_REGEX,
+    (options && options.local) ? '$1' : ''
+  );
+
+  filename = filename.replace(
+    NODE_ENV_PLACEHOLDER_REGEX,
+    (options && options.node_env) ? `$1${options.node_env}$2` : ''
+  );
+
+  return filename;
+}
+
+/**
+ * Returns a list of `.env*` filenames depending on the given `options`.
+ *
+ * The resulting list is ordered by the env files'
+ * variables overwriting priority from lowest to highest.
+ * This is also referenced as "env files' environment cascade."
+ *
+ * ⚠️ Note that the `.env.local` file is not listed for "test" environment,
  * since normally you expect tests to produce the same results for everyone.
  *
- * @param {string} dirname - path to `.env*` files' directory
  * @param {object} [options] - `.env*` files listing options
- * @param {string} [options.node_env] - node environment (development/test/production/etc,.)
+ * @param {string} [options.node_env] - node environment (development/test/production/etc.)
+ * @param {string} [options.pattern] - `.env*` files' naming convention pattern
+ *                                       (default: ".env[.node_env][.local]")
  * @return {string[]}
  */
-function listFiles(dirname, options = {}) {
-  const {node_env} = options;
+function listFiles(options = {}) {
+  const {
+    node_env,
+    pattern = DEFAULT_PATTERN,
+  } = options;
 
-  return [
-    resolve(dirname, '.env.defaults'),
-    resolve(dirname, '.env'),
-    (node_env !== 'test') && resolve(dirname, '.env.local'),
-    node_env && resolve(dirname, `.env.${node_env}`),
-    node_env && resolve(dirname, `.env.${node_env}.local`)
-  ]
-    .filter(filename => Boolean(filename));
+  const includeLocals = LOCAL_PLACEHOLDER_REGEX.test(pattern);
+
+  const filenames = [];
+
+  if (pattern === DEFAULT_PATTERN) {
+    filenames.push('.env.defaults'); // for seamless transition from ".env + .env.defaults"
+  }
+
+  filenames.push(composeFilename(pattern)); // '.env'
+
+  if (node_env !== 'test' && includeLocals) {
+    filenames.push(composeFilename(pattern, { local: true })); // '.env.local'
+  }
+
+  if (node_env && NODE_ENV_PLACEHOLDER_REGEX.test(pattern)) {
+    filenames.push(
+      composeFilename(pattern, { node_env }) // `.env.${NODE_ENV}` (i.e. '.env.development')
+    );
+
+    if (includeLocals) {
+      filenames.push(
+        composeFilename(pattern, { node_env, local: true }) // `.env.${NODE_ENV}.local`
+      );
+    }
+  }
+
+  return filenames;
 }
 
 /**
@@ -118,9 +175,10 @@ function unload(filenames, options = {}) {
  * Main entry point into the "dotenv-flow". Allows configuration before loading `.env*` files.
  *
  * @param {object} [options] - configuration options
- * @param {string} [options.node_env=process.env.NODE_ENV] - node environment (development/test/production/etc,.)
+ * @param {string} [options.node_env=process.env.NODE_ENV] - node environment (development/test/production/etc.)
  * @param {string} [options.default_node_env] - the default node environment
  * @param {string} [options.path=process.cwd()] - path to `.env*` files directory
+ * @param {string} [options.pattern=".env[.node_env][.local]"] - `.env*` files' naming convention pattern
  * @param {string} [options.encoding="utf8"] - encoding of `.env*` files
  * @param {boolean} [options.purge_dotenv=false] - perform the `.env` file {@link unload}
  * @param {boolean} [options.silent=false] - suppress all the console outputs except errors and deprecations
@@ -142,7 +200,8 @@ function config(options = {}) {
   }
 
   const {
-    encoding = undefined,
+    pattern,
+    encoding,
     silent = false
   } = options;
 
@@ -158,7 +217,8 @@ function config(options = {}) {
 
   try {
     const existingFiles = (
-      listFiles(path, { node_env })
+      listFiles({ node_env, pattern })
+        .map(basename => resolve(path, basename))
         .filter(filename => fs.existsSync(filename))
     );
 
@@ -179,7 +239,6 @@ function config(options = {}) {
 
 module.exports = {
   listFiles,
-  listDotenvFiles: listFiles, // for API backward compatibility
   parse,
   load,
   unload,


### PR DESCRIPTION
### Sumary

This PR introduces a new configuration option `pattern`. It allows users to define a custom naming convention for `.env*` files that dotenv-flow will read.

The default value for the `pattern` option is `".env[.node_env][.local]"` which is fully backward-compatible with the current dotenv-flow's naming convention.

### Description

`options.pattern` allows you to change the default `.env*` files' naming convention if you want to have a specific file naming structure for maintaining your environment variables' files.

#### Default Value

The default value `".env[.node_env][.local]"` makes *dotenv-flow* look up and load the following files in order:

1. `.env`
2. `.env.local`
3. `.env.${NODE_ENV}`
4. `.env.${NODE_ENV}.local`

For example, when the `proess.env.NODE_ENV` (or `options.node_env`) is set to `"development"`, *dotenv-flow* will be looking for and parsing (if found) the following files:

1. `.env`
2. `.env.local`
3. `.env.development`
4. `.env.development.local`

#### Custom Patterns

Here are a couple of examples of customizing the `.env*` files naming convention:

For example, if you set the pattern to `".env/[local/]env[.node_env]"`, *dotenv-flow* will look for these files instead:

1. `.env/env`
2. `.env/local/env`
3. `.env/env.development`
4. `.env/local/env.development`

… or if you set the pattern to `".env/[.node_env/].env[.node_env][.local]"`, *dotenv-flow* will try to find and parse:

1. `.env/.env`
2. `.env/.env.local`
3. `.env/development/.env.development`
4. `.env/development/.env.development.local`

› Please refer to [`.listFiles([options])`](#listfiles-options--string) to dive deeper.

BREAKING CHANGE: `.listFiles()` (exposed internal API method) doesn't receive `dirname` anymore and returns a list of filenames without the full path (just the name of the file).