### PR TITLE
feat(dotenv-flow): remove deprecated `options.cwd`

### DIFF
--- a/lib/dotenv-flow.js
+++ b/lib/dotenv-flow.js
@@ -185,21 +185,9 @@ function unload(filenames, options = {}) {
  * @return {{ parsed?: object, error?: Error }} with a `parsed` key containing the loaded content or an `error` key with an error that is occurred
  */
 function config(options = {}) {
-  const node_env = options.node_env || process.env.NODE_ENV || options.default_node_env;
-
-  let path;
-  if (options.path) {
-    path = options.path;
-  }
-  else if (options.cwd) {
-    console.warn('dotenv-flow: `options.cwd` is deprecated, please use `options.path` instead'); // >>>
-    path = options.cwd;
-  }
-  else {
-    path = process.cwd();
-  }
-
   const {
+    node_env = process.env.NODE_ENV || options.default_node_env,
+    path = process.cwd(),
     pattern,
     encoding,
     silent = false


### PR DESCRIPTION
This PR removes configuration option `cwd` that was deprecated sice v3.x

BREAKING CHANGE: `options.cwd` is removed, use `options.path` instead.