### PR TITLE
feat(dotenv-flow): rework `.listFiles` to return only existing files + their full paths

### DIFF
--- a/lib/dotenv-flow.js
+++ b/lib/dotenv-flow.js
@@ -35,17 +35,20 @@ function composeFilename(pattern, options) {
 }
 
 /**
- * Returns a list of `.env*` filenames depending on the given `options`.
+ * Returns a list of existing `.env*` filenames depending on the given `options`.
  *
  * The resulting list is ordered by the env files'
  * variables overwriting priority from lowest to highest.
- * This is also referenced as "env files' environment cascade."
+ *
+ * This can also be referenced as "env files' environment cascade"
+ * or "order of ascending priority."
  *
  * ⚠️ Note that the `.env.local` file is not listed for "test" environment,
  * since normally you expect tests to produce the same results for everyone.
  *
  * @param {object} [options] - `.env*` files listing options
  * @param {string} [options.node_env] - node environment (development/test/production/etc.)
+ * @param {object} [options.path] - path to the working directory (default: `process.cwd()`)
  * @param {string} [options.pattern] - `.env*` files' naming convention pattern
  *                                       (default: ".env[.node_env][.local]")
  * @return {string[]}
@@ -53,36 +56,51 @@ function composeFilename(pattern, options) {
 function listFiles(options = {}) {
   const {
     node_env,
+    path = process.cwd(),
     pattern = DEFAULT_PATTERN,
   } = options;
 
   const includeLocals = LOCAL_PLACEHOLDER_REGEX.test(pattern);
 
-  const filenames = [];
+  const filenames = {};
 
   if (pattern === DEFAULT_PATTERN) {
-    filenames.push('.env.defaults'); // for seamless transition from ".env + .env.defaults"
+    filenames['.env.defaults'] = '.env.defaults'; // for seamless transition from ".env + .env.defaults"
   }
 
-  filenames.push(composeFilename(pattern)); // '.env'
+  filenames['.env'] = composeFilename(pattern);
 
   if (node_env !== 'test' && includeLocals) {
-    filenames.push(composeFilename(pattern, { local: true })); // '.env.local'
+    filenames['.env.local'] = composeFilename(pattern, { local: true });
   }
 
   if (node_env && NODE_ENV_PLACEHOLDER_REGEX.test(pattern)) {
-    filenames.push(
-      composeFilename(pattern, { node_env }) // `.env.${NODE_ENV}` (i.e. '.env.development')
-    );
+    filenames['.env.<node_env>'] = composeFilename(pattern, { node_env });
 
     if (includeLocals) {
-      filenames.push(
-        composeFilename(pattern, { node_env, local: true }) // `.env.${NODE_ENV}.local`
-      );
+      filenames['.env.<node_env>.local'] = composeFilename(pattern, { node_env, local: true });
     }
   }
 
-  return filenames;
+  return [
+    '.env.defaults',
+    '.env',
+    '.env.local',
+    '.env.<node_env>',
+    '.env.<node_env>.local'
+  ]
+    .reduce((list, basename) => {
+      if (!filenames[basename]) {
+        return list;
+      }
+
+      const filename = p.resolve(path, filenames[basename]);
+      if (fs.existsSync(filename)) {
+        list.push(filename);
+      }
+
+      return list;
+    }, []);
 }
 
 /**
@@ -204,13 +222,9 @@ function config(options = {}) {
   }
 
   try {
-    const existingFiles = (
-      listFiles({ node_env, pattern })
-        .map(basename => p.resolve(path, basename))
-        .filter(filename => fs.existsSync(filename))
-    );
+    const filenames = listFiles({ node_env, path, pattern });
 
-    if (existingFiles.length === 0) {
+    if (filenames.length === 0) {
       const _pattern = node_env
         ? pattern.replace(NODE_ENV_PLACEHOLDER_REGEX, `[$1${node_env}$2]`)
         : pattern;
@@ -220,7 +234,7 @@ function config(options = {}) {
       };
     }
 
-    return load(existingFiles, { encoding, silent });
+    return load(filenames, { encoding, silent });
   }
   catch (error) {
     return { error };


### PR DESCRIPTION
BREAKING CHANGE: `.listFiles` now lists only existing files and their full paths