### PR TITLE
feat(dotenv-flow): add debug messaging and errors warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Using PNPM:
 $ pnpm add dotenv-flow
 ```
 
+
 ## Usage
 
 As early as possible in your Node.js app, initialize **dotenv-flow**:
@@ -297,7 +298,9 @@ Then at every place `.env` is mentioned in the docs, read it as: "`.env.defaults
 
 ## `dotenv-flow/config` options
 
-When preloading **dotenv-flow** using the node's `-r` switch you can use the following configuration options:
+The following configuration options can be used when:
+  a) preloading **dotenv-flow** using Node's `-r` (`[ts-]node --require`) switch, or…
+  b) `import`ing the `dotenv-flow/config` entry point.
 
 ### Environment variables
 
@@ -306,8 +309,10 @@ When preloading **dotenv-flow** using the node's `-r` switch you can use the fol
 * `DOTENV_FLOW_PATH` => [`options.path`](#optionspath);
 * `DOTENV_FLOW_ENCODING` => [`options.encoding`](#optionsencoding);
 * `DOTENV_FLOW_PURGE_DOTENV` => [`options.purge_dotenv`](#optionspurge_dotenv);
+* `DOTENV_FLOW_DEBUG` => [`options.debug`](#optionsdebug);
 * `DOTENV_FLOW_SILENT` => [`options.silent`](#optionssilent);
 
+##### _for example:_
 ```sh
 $ NODE_ENV=production DOTENV_FLOW_PATH=/path/to/env-files-dir node -r dotenv-flow/config your_script.js
 ```
@@ -319,12 +324,14 @@ $ NODE_ENV=production DOTENV_FLOW_PATH=/path/to/env-files-dir node -r dotenv-flo
 * `--dotenv-flow-path` => [`options.path`](#optionspath);
 * `--dotenv-flow-encoding` => [`options.encoding`](#optionsencoding);
 * `--dotenv-flow-purge-dotenv` => [`options.purge_dotenv`](#optionspurge_dotenv);
+* `--dotenv-flow-debug` => [`options.debug`](#optionsdebug);
 * `--dotenv-flow-silent` => [`options.silent`](#optionssilent);
 
-Don't forget to separate **dotenv-flow/config**-specific CLI switches with `--` because they are not recognized by **Node.js**:
+> Make sure that **dotenv-flow/config**-specific CLI switches are separated from Node's by `--` (double dash) since they are not recognized by **Node.js**.
 
+##### _for example:_
 ```sh
-$ node -r dotenv-flow/config your_script.js -- --dotenv-flow-encoding=latin1 --dotenv-flow-path=...
+$ node --require dotenv-flow/config your_script.js -- --dotenv-flow-path=/path/to/project --dotenv-flow-encoding=base64
 ```
 
 
@@ -332,9 +339,13 @@ $ node -r dotenv-flow/config your_script.js -- --dotenv-flow-encoding=latin1 --d
 
 #### `.config([options]) => object`
 
-The main entry point function that parses the contents of your `.env*` files, merges the results and appends to `process.env.*`.
+"dotenv-flow" initialization function (API entry point).
 
-Also, like the original module ([dotenv](https://github.com/motdotla/dotenv)), it returns an `object` with the `parsed` property containing the resulting key/values or the `error` property if the initialization is failed.
+Allows configuring dotenv-flow programmatically.
+
+Also, like the original module ([dotenv](https://github.com/motdotla/dotenv)),
+it returns an `object` with `.parsed` property containing the resulting
+`varname => values` pairs or `.error` property if the initialization is failed.
 
 ##### `options.node_env`
 ###### Type: `string`
@@ -478,11 +489,17 @@ require('dotenv-flow').config({
 });
 ```
 
+##### `options.debug`
+###### Type: `boolean`
+###### Default: `false`
+
+Enables detailed logging to debug why certain variables are not being set as you expect.
+
 ##### `options.silent`
 ###### Type: `boolean`
 ###### Default: `false`
 
-With this option you can suppress all the console outputs except errors and deprecation warnings.
+Suppresses all kinds of warnings including ".env*" files' loading errors.
 
 ```js
 require('dotenv-flow').config({
@@ -492,16 +509,19 @@ require('dotenv-flow').config({
 
 ---
 
-The following API considered as internal, but it is also exposed to give the ability to be used programmatically by your own needs.
+The following API is considered as internal, although it's exposed
+for programmatic use of **dotenv-flow** for your own project-specific needs.
 
 
 #### `.listFiles([options]) => string[]`
 
-Returns a list of `.env*` filenames depending on the given `options`.
+Returns a list of existing `.env*` filenames depending on the given `options`.
 
 The resulting list is ordered by the env files'
 variables overwriting priority from lowest to highest.
-This is also referenced as "env files' environment cascade."
+
+This can also be referenced as "env files' environment cascade"
+or "order of ascending priority."
 
 ⚠️ Note that the `.env.local` file is not listed for "test" environment,
 since normally you expect tests to produce the same results for everyone.
@@ -568,6 +588,13 @@ which (as mentioned above) will exclude `.env.local` producing just a single:
 … since normally we expect tests to produce the same results for everyone.
 
 
+##### `options.debug`
+###### Type: `boolean`
+###### Default: `false`
+
+Enables debug messages.
+
+
 ##### Returns:
 
 ###### Type: `string[]`
@@ -605,11 +632,19 @@ When several filenames are given, the parsed variables are merged into a single 
 
 A filename or a list of filenames to parse.
 
+
 ##### `options.encoding`
 ###### Type: `string`
 ###### Default: `"utf8"`
 
 An optional encoding for reading files.
+
+
+##### `options.debug`
+###### Type: `boolean`
+###### Default: `false`
+
+Enables debug messages.
 
 
 ##### Returns:
@@ -667,11 +702,17 @@ A filename or a list of filenames to load.
 
 An optional encoding for reading files.
 
+##### `options.debug`
+###### Type: `boolean`
+###### Default: `false`
+
+Optionally, turn on debug messages.
+
 ##### `options.silent`
 ###### Type: `boolean`
 ###### Default: `false`
 
-Suppress all the console outputs except errors and deprecation warnings.
+If enabled, suppresses all kinds of warnings including ".env*" files' loading errors.
 
 ##### Returns:
 

--- a/lib/cli-options.js
+++ b/lib/cli-options.js
@@ -6,6 +6,7 @@ const CLI_OPTIONS_MAP = {
   '--dotenv-flow-path': 'path',
   '--dotenv-flow-encoding': 'encoding',
   '--dotenv-flow-purge-dotenv': 'purge_dotenv',
+  '--dotenv-flow-debug': 'debug',
   '--dotenv-flow-silent': 'silent'
 };
 

--- a/lib/dotenv-flow.js
+++ b/lib/dotenv-flow.js
@@ -3,6 +3,7 @@
 const fs = require('fs');
 const p = require('path');
 const dotenv = require('dotenv');
+const {version} = require('../package.json');
 
 const DEFAULT_PATTERN = '.env[.node_env][.local]';
 
@@ -51,16 +52,19 @@ function composeFilename(pattern, options) {
  * @param {object} [options.path] - path to the working directory (default: `process.cwd()`)
  * @param {string} [options.pattern] - `.env*` files' naming convention pattern
  *                                       (default: ".env[.node_env][.local]")
+ * @param {boolean} [options.debug] - turn on debug messages
  * @return {string[]}
  */
 function listFiles(options = {}) {
+  options.debug && debug('listing effective `.env*` files…');
+
   const {
     node_env,
     path = process.cwd(),
     pattern = DEFAULT_PATTERN,
   } = options;
 
-  const includeLocals = LOCAL_PLACEHOLDER_REGEX.test(pattern);
+  const hasLocalPlaceholder = LOCAL_PLACEHOLDER_REGEX.test(pattern);
 
   const filenames = {};
 
@@ -70,15 +74,25 @@ function listFiles(options = {}) {
 
   filenames['.env'] = composeFilename(pattern);
 
-  if (node_env !== 'test' && includeLocals) {
-    filenames['.env.local'] = composeFilename(pattern, { local: true });
+  if (hasLocalPlaceholder) {
+    const envlocal = composeFilename(pattern, { local: true });
+
+    if (node_env !== 'test') {
+      filenames['.env.local'] = envlocal;
+    }
+    else if (options.debug && fs.existsSync(p.resolve(path, envlocal))) {
+      debug(
+        '[!] note that `%s` is being skipped for "test" environment',
+        envlocal
+      );
+    }
   }
 
   if (node_env && NODE_ENV_PLACEHOLDER_REGEX.test(pattern)) {
-    filenames['.env.<node_env>'] = composeFilename(pattern, { node_env });
+    filenames['.env.node_env'] = composeFilename(pattern, { node_env });
 
-    if (includeLocals) {
-      filenames['.env.<node_env>.local'] = composeFilename(pattern, { node_env, local: true });
+    if (hasLocalPlaceholder) {
+      filenames['.env.node_env.local'] = composeFilename(pattern, { node_env, local: true });
     }
   }
 
@@ -86,8 +100,8 @@ function listFiles(options = {}) {
     '.env.defaults',
     '.env',
     '.env.local',
-    '.env.<node_env>',
-    '.env.<node_env>.local'
+    '.env.node_env',
+    '.env.node_env.local'
   ]
     .reduce((list, basename) => {
       if (!filenames[basename]) {
@@ -96,6 +110,7 @@ function listFiles(options = {}) {
 
       const filename = p.resolve(path, filenames[basename]);
       if (fs.existsSync(filename)) {
+        options.debug && debug('>> %s', filename);
         list.push(filename);
       }
 
@@ -109,16 +124,38 @@ function listFiles(options = {}) {
  * When a list of filenames is given, the files will be parsed and merged in the same order as given.
  *
  * @param {string|string[]} filenames - filename or a list of filenames to parse and merge
- * @param {{ encoding?: string }} [options] - `fs.readFileSync` options
+ * @param {{ encoding?: string, debug:? boolean }} [options] - parse options
  * @return {Object<string, string>} the resulting map of `{ env_var: value }` as an object
  */
-function parse(filenames, options) {
+function parse(filenames, options = {}) {
   if (typeof filenames === 'string') {
-    return dotenv.parse(fs.readFileSync(filenames, options));
+    options.debug && debug('parsing "%s"…', filenames);
+
+    const parsed = dotenv.parse(
+      fs.readFileSync(
+        filenames,
+        options.encoding && { encoding: options.encoding }
+      )
+    );
+
+    if (options.debug) {
+      Object.keys(parsed)
+        .forEach(varname => debug('>> %s', varname));
+    }
+
+    return parsed;
   }
 
-  return filenames.reduce((parsed, filename) => {
-    return Object.assign(parsed, parse(filename, options));
+  return filenames.reduce((result, filename) => {
+    const parsed = parse(filename, options);
+
+    if (options.debug) {
+      Object.keys(parsed)
+        .filter(varname => result.hasOwnProperty(varname))
+        .forEach(varname => debug('`%s` is being overwritten by merge from "%s"', varname, filename));
+    }
+
+    return Object.assign(result, parsed);
   }, {});
 }
 
@@ -139,29 +176,33 @@ function parse(filenames, options) {
  * @param {string|string[]} filenames - filename or a list of filenames to parse and merge
  * @param {object} [options] - file loading options
  * @param {string} [options.encoding="utf8"] - encoding of `.env*` files
- * @param {boolean} [options.silent=false] - suppress all the console outputs except errors and deprecations
+ * @param {boolean} [options.debug=false] - turn on debug messages
+ * @param {boolean} [options.silent=false] - suppress console errors and warnings
  * @return {{ error: Error } | { parsed: Object<string, string> }}
  */
-function load(filenames, options) {
-  const _options = (options && options.encoding) ? { encoding: options.encoding } : undefined;
-  const _verbose = !(options && options.silent);
-
+function load(filenames, options = {}) {
   try {
-    const parsed = parse(filenames, _options);
+    const parsed = parse(filenames, {
+      encoding: options.encoding,
+      debug: options.debug
+    });
+
+    options.debug && debug('safe-merging parsed environment variables into `process.env`…');
 
     for (const varname of Object.keys(parsed)) {
       if (!process.env.hasOwnProperty(varname)) {
+        options.debug && debug('>> process.env.%s', varname);
         process.env[varname] = parsed[varname];
       }
-      else if (_verbose) {
-        console.warn('dotenv-flow: "%s" is already defined in `process.env` and will not be overwritten', varname); // >>>
+      else if (options.debug && process.env[varname] !== parsed[varname]) {
+        debug('environment variable `%s` is predefined and not being overwritten', varname);
       }
     }
 
     return { parsed };
   }
   catch (error) {
-    return { error };
+    return failure(error, options);
   }
 }
 
@@ -190,7 +231,56 @@ function unload(filenames, options = {}) {
 }
 
 /**
- * Main entry point into the "dotenv-flow". Allows configuration before loading `.env*` files.
+ * Returns effective (computed) `node_env`.
+ *
+ * @param {object} [options]
+ * @param {string} [options.node_env]
+ * @param {string} [options.default_node_env]
+ * @param {boolean} [options.debug]
+ * @return {string|undefined} node_env
+ */
+function getEffectiveNodeEnv(options = {}) {
+  if (options.node_env) {
+    options.debug && debug(
+      `operating in "${options.node_env}" environment (set by \`options.node_env\`)`
+    );
+    return options.node_env;
+  }
+
+  if (process.env.NODE_ENV) {
+    options.debug && debug(
+      `operating in "${process.env.NODE_ENV}" environment (as per \`process.env.NODE_ENV\`)`
+    );
+    return process.env.NODE_ENV;
+  }
+
+  if (options.default_node_env) {
+    options.debug && debug(
+      `operating in "${options.default_node_env}" environment (taken from \`options.default_node_env\`)`
+    );
+    return options.default_node_env;
+  }
+
+  options.debug && debug(
+    'operating in "no environment" mode (no environment-related options are set)'
+  );
+  return undefined;
+}
+
+const CONFIG_OPTION_KEYS = [
+  'node_env',
+  'default_node_env',
+  'path',
+  'pattern',
+  'encoding',
+  'purge_dotenv',
+  'silent'
+];
+
+/**
+ * "dotenv-flow" initialization function (API entry point).
+ *
+ * Allows configuring dotenv-flow programmatically.
  *
  * @param {object} [options] - configuration options
  * @param {string} [options.node_env=process.env.NODE_ENV] - node environment (development/test/production/etc.)
@@ -199,46 +289,87 @@ function unload(filenames, options = {}) {
  * @param {string} [options.pattern=".env[.node_env][.local]"] - `.env*` files' naming convention pattern
  * @param {string} [options.encoding="utf8"] - encoding of `.env*` files
  * @param {boolean} [options.purge_dotenv=false] - perform the `.env` file {@link unload}
- * @param {boolean} [options.silent=false] - suppress all the console outputs except errors and deprecations
+ * @param {boolean} [options.debug=false] - turn on detailed logging to help debug why certain variables are not being set as you expect
+ * @param {boolean} [options.silent=false] - suppress all kinds of warnings including ".env*" files' loading errors
  * @return {{ parsed?: object, error?: Error }} with a `parsed` key containing the loaded content or an `error` key with an error that is occurred
  */
 function config(options = {}) {
+  if (options.debug) {
+    debug('initializing…');
+
+    CONFIG_OPTION_KEYS
+      .filter(key => key in options)
+      .forEach(key => debug(`| options.${key} =`, options[key]));
+  }
+
+  const node_env = getEffectiveNodeEnv(options);
+
   const {
-    node_env = process.env.NODE_ENV || options.default_node_env,
     path = process.cwd(),
-    pattern = DEFAULT_PATTERN,
-    encoding,
-    silent = false
+    pattern = DEFAULT_PATTERN
   } = options;
 
   if (options.purge_dotenv) {
+    options.debug && debug(
+      '`options.purge_dotenv` is enabled, unloading potentially pre-loaded `.env`…'
+    );
+
     const dotenvFile = p.resolve(path, '.env');
     try {
-      fs.existsSync(dotenvFile) && unload(dotenvFile, { encoding });
+      fs.existsSync(dotenvFile) && unload(dotenvFile, { encoding: options.encoding });
     }
     catch (error) {
-      return { error };
+      !options.silent && warn('unloading failed: ', error);
     }
   }
 
   try {
-    const filenames = listFiles({ node_env, path, pattern });
+    const filenames = listFiles({ node_env, path, pattern, debug: options.debug });
 
     if (filenames.length === 0) {
       const _pattern = node_env
         ? pattern.replace(NODE_ENV_PLACEHOLDER_REGEX, `[$1${node_env}$2]`)
         : pattern;
 
-      return {
-        error: new Error(`no ".env*" files matching pattern "${_pattern}" in "${path}" dir`)
-      };
+      return failure(
+        new Error(`no ".env*" files matching pattern "${_pattern}" in "${path}" dir`),
+        options
+      );
     }
 
-    return load(filenames, { encoding, silent });
+    const result = load(filenames, {
+      encoding: options.encoding,
+      debug: options.debug,
+      silent: options.silent
+    });
+
+    options.debug && debug('initialization completed.');
+
+    return result;
   }
   catch (error) {
-    return { error };
+    return failure(error, options);
   }
+}
+
+function failure(error, options) {
+  if (!options.silent) {
+    warn(`".env*" files loading failed: ${error.message || error}`);
+  }
+
+  return { error };
+}
+
+function warn(message, error) {
+  if (error) {
+    message += ': %s';
+  }
+
+  console.warn(`[dotenv-flow@${version}]: ${message}`, error);
+}
+
+function debug(message, ...values) {
+  console.debug(`[dotenv-flow@${version}]: ${message}`, ...values);
 }
 
 module.exports = {

--- a/lib/env-options.js
+++ b/lib/env-options.js
@@ -6,6 +6,7 @@ const ENV_OPTIONS_MAP = {
   DOTENV_FLOW_PATH: 'path',
   DOTENV_FLOW_ENCODING: 'encoding',
   DOTENV_FLOW_PURGE_DOTENV: 'purge_dotenv',
+  DOTENV_FLOW_DEBUG: 'debug',
   DOTENV_FLOW_SILENT: 'silent'
 };
 

--- a/test/integration/exports.spec.mjs
+++ b/test/integration/exports.spec.mjs
@@ -1,9 +1,37 @@
 import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { expect } from 'chai';
+import sinon from 'sinon';
 
-const require = createRequire(import.meta.url)
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const require = createRequire(import.meta.url);
 
 describe('exports', () => {
+  let _processEnvBackup;
+
+  before('backup the original `process.env` object', () => {
+    _processEnvBackup = process.env;
+  });
+
+  beforeEach('setup the `process.env` copy', () => {
+    process.env = { ..._processEnvBackup };
+  });
+
+  after('restore the original `process.env` object', () => {
+    process.env = _processEnvBackup;
+  });
+
+  beforeEach('stub `process.cwd()`', () => {
+    sinon.stub(process, 'cwd')
+      .returns(resolve(__dirname, 'fixtures', 'env'));
+  });
+
+  afterEach('restore `process.cwd()`', () => {
+    process.cwd.restore();
+  });
+
   describe('commonjs', () => {
     it('should load module using require', () => {
       const dotenv = require('../..')

--- a/test/unit/cli-options.spec.js
+++ b/test/unit/cli-options.spec.js
@@ -13,7 +13,8 @@ describe('cli_options', () => {
       '--dotenv-flow-path', '/path/to/project',
       '--dotenv-flow-encoding', 'latin1',
       '--dotenv-flow-purge-dotenv', 'yes',
-      '--dotenv-flow-silent', 'yes'
+      '--dotenv-flow-debug', 'enabled',
+      '--dotenv-flow-silent', 'true'
     ]))
       .to.deep.equal({
         node_env: 'production',
@@ -21,7 +22,8 @@ describe('cli_options', () => {
         path: '/path/to/project',
         encoding: 'latin1',
         purge_dotenv: 'yes',
-        silent: 'yes'
+        debug: 'enabled',
+        silent: 'true'
       });
   });
 
@@ -34,7 +36,8 @@ describe('cli_options', () => {
       '--dotenv-flow-path=/path/to/project',
       '--dotenv-flow-encoding=latin1',
       '--dotenv-flow-purge-dotenv=yes',
-      '--dotenv-flow-silent=yes'
+      '--dotenv-flow-debug=enabled',
+      '--dotenv-flow-silent=true'
     ]))
       .to.deep.equal({
         node_env: 'production',
@@ -42,7 +45,8 @@ describe('cli_options', () => {
         path: '/path/to/project',
         encoding: 'latin1',
         purge_dotenv: 'yes',
-        silent: 'yes'
+        debug: 'enabled',
+        silent: 'true'
       });
   });
 

--- a/test/unit/env-options.spec.js
+++ b/test/unit/env-options.spec.js
@@ -11,7 +11,8 @@ describe('env_options', () => {
       DOTENV_FLOW_PATH: '/path/to/project',
       DOTENV_FLOW_ENCODING: 'latin1',
       DOTENV_FLOW_PURGE_DOTENV: 'yes',
-      DOTENV_FLOW_SILENT: 'yes'
+      DOTENV_FLOW_DEBUG: 'enabled',
+      DOTENV_FLOW_SILENT: 'true'
     }))
       .to.deep.equal({
         node_env: 'production',
@@ -19,7 +20,8 @@ describe('env_options', () => {
         path: '/path/to/project',
         encoding: 'latin1',
         purge_dotenv: 'yes',
-        silent: 'yes'
+        debug: 'enabled',
+        silent: 'true'
       });
   });
 


### PR DESCRIPTION
This PR adds informative (yet secure) "debug" and "warn" messages which adds more clarity on what's happening under the dotenv-flow's hood in certain scenarios, depending on the given environment, and set of options.

- debug messages can be enabled via `options.debug`,
- while warnings are enabled by default and can be disabled via `options.silent`.
