### PR TITLE
fix(dotenv-flow): block the ability to `import "dotenv-flow/config"`

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,29 +50,29 @@ require('dotenv-flow').config();
 
 It will allow you to configure and use **dotenv-flow** from your code programmatically.
 
+If you're using TypeScript or ES Modules:
+
+```ts
+import dotenvFlow from 'dotenv-flow';
+dotenvFlow.config();
+```
+
 Alternatively, you can use the default config entry point that allows you to configure **dotenv-flow** using command switch flags or predefined environment variables:
 
 ```js
 require('dotenv-flow/config');
 ```
 
-Or, you may want **dotenv-flow** to load environment variables for your app without adding it to the code via Node's `--require` flag, for example:
+Or even make **dotenv-flow** load environment variables for your app without adding it to the code using preload technique:
 
 ```sh
 $ node -r "dotenv-flow/config" your_app.js
 ```
 
-If you're using TypeScript (or ES6+ modules), to import the default config entry point (and configure **dotenv-flow** via CLI switches or env vars):
+It works with `ts-node` as well:
 
-```ts
-import 'dotenv-flow/config';
-```
-
-Or, to use/configure it programmatically:
-
-```ts
-import dotenvFlow from 'dotenv-flow';
-dotenvFlow.config();
+```sh
+$ ts-node -r "dotenv-flow/config" your_app.ts
 ```
 
 ### How it works
@@ -299,8 +299,8 @@ Then at every place `.env` is mentioned in the docs, read it as: "`.env.defaults
 ## `dotenv-flow/config` options
 
 The following configuration options can be used when:
-  a) preloading **dotenv-flow** using Node's `-r` (`[ts-]node --require`) switch, or…
-  b) `import`ing the `dotenv-flow/config` entry point.
+- a) preloading **dotenv-flow** using Node's `-r` (`[ts-]node --require`) switch, or…
+- b) `require`ing the `dotenv-flow/config` entry point (using `require('dotenv-flow/config');`).
 
 ### Environment variables
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
   "types": "lib/dotenv-flow.d.ts",
   "exports": {
     ".": "./lib/dotenv-flow.js",
-    "./config": "./config.js",
+    "./config": {
+      "require": "./config.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/test/integration/exports.spec.mjs
+++ b/test/integration/exports.spec.mjs
@@ -32,9 +32,9 @@ describe('exports', () => {
     process.cwd.restore();
   });
 
-  describe('commonjs', () => {
+  describe('CommonJS', () => {
     it('should load module using require', () => {
-      const dotenv = require('../..')
+      const dotenv = require('dotenv-flow'); // self-require
 
       expect(dotenv).to.include.keys([
         'listFiles',
@@ -46,7 +46,7 @@ describe('exports', () => {
     });
   });
 
-  describe('esm', () => {
+  describe('ES Module', () => {
     it('should load module using import', async () => {
       const dotenv = await import('dotenv-flow'); // self-import
 
@@ -58,11 +58,6 @@ describe('exports', () => {
         'unload',
         'default'
       ]);
-    });
-
-    it('should load config entry point', async () => {
-      // just checking that it doesn't throw, ideally should test that it loads some env too
-      await import('dotenv-flow/config'); // self-import
     });
   });
 });


### PR DESCRIPTION
Given that `dotenv-flow/config` is not an exporting module but an executable script,
it doesn't work when importing as an ES Module or from within TypeScript.

This CR changes the `package.json`'s `"exports"` field declaration
blocking the ability to `import "dotenv-flow/config"` to avoid the above
confusion.