### PR TITLE
fix(dotenv-flow:reload): add `node` resolver for `exports:./config` field, fixes #81

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "exports": {
     ".": "./lib/dotenv-flow.js",
     "./config": {
-      "require": "./config.js"
+      "require": "./config.js",
+      "node": "./config.js"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
This change fixes the issue with preloading `dotenv-flow/config` using Mocha's `-r` switch.