### PR TITLE
feat(dotenv-flow): implement `options.files`, closes #83

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,24 @@ For example, if you set the pattern to `".env/[local/]env[.node_env]"`,
 
 › Please refer to [`.listFiles([options])`](#listfiles-options--string) to dive deeper.
 
+##### `options.files`
+###### Type: `string[]`
+
+Allows explicitly specifying a list (and the order) of `.env*` files to load.
+
+Note that options like `node_env`, `default_node_env`, and `pattern` are ignored in this case.
+
+```js
+require('dotenv-flow').config({
+  files: [
+    '.env',
+    '.env.local',
+    `.env.${process.env.NODE_ENV}`, // '.env.development'
+    `.env.${process.env.NODE_ENV}.local` // '.env.development.local'
+  ]
+});
+```
+
 ##### `options.encoding`
 ###### Type: `string`
 ###### Default: `"utf8"`

--- a/lib/dotenv-flow.d.ts
+++ b/lib/dotenv-flow.d.ts
@@ -113,6 +113,7 @@ export function unload(filenames: string | string[], options?: DotenvFlowParseOp
 export type DotenvFlowConfigOptions = DotenvFlowListFilesOptions & DotenvFlowLoadOptions & {
   default_node_env?: string;
   purge_dotenv?: boolean;
+  files?: string[];
 }
 
 export type DotenvFlowConfigResult<T extends DotenvFlowParseResult = DotenvFlowParseResult> = DotenvFlowLoadResult<T>;

--- a/lib/dotenv-flow.js
+++ b/lib/dotenv-flow.js
@@ -272,6 +272,7 @@ const CONFIG_OPTION_KEYS = [
   'default_node_env',
   'path',
   'pattern',
+  'files',
   'encoding',
   'purge_dotenv',
   'silent'
@@ -287,6 +288,7 @@ const CONFIG_OPTION_KEYS = [
  * @param {string} [options.default_node_env] - the default node environment
  * @param {string} [options.path=process.cwd()] - path to `.env*` files directory
  * @param {string} [options.pattern=".env[.node_env][.local]"] - `.env*` files' naming convention pattern
+ * @param {string[]} [options.files] - an explicit list of `.env*` files to load (note that `options.[default_]node_env` and `options.pattern` are ignored in this case)
  * @param {string} [options.encoding="utf8"] - encoding of `.env*` files
  * @param {boolean} [options.purge_dotenv=false] - perform the `.env` file {@link unload}
  * @param {boolean} [options.debug=false] - turn on detailed logging to help debug why certain variables are not being set as you expect
@@ -301,8 +303,6 @@ function config(options = {}) {
       .filter(key => key in options)
       .forEach(key => debug(`| options.${key} =`, options[key]));
   }
-
-  const node_env = getEffectiveNodeEnv(options);
 
   const {
     path = process.cwd(),
@@ -324,17 +324,43 @@ function config(options = {}) {
   }
 
   try {
-    const filenames = listFiles({ node_env, path, pattern, debug: options.debug });
+    let filenames;
 
-    if (filenames.length === 0) {
-      const _pattern = node_env
-        ? pattern.replace(NODE_ENV_PLACEHOLDER_REGEX, `[$1${node_env}$2]`)
-        : pattern;
-
-      return failure(
-        new Error(`no ".env*" files matching pattern "${_pattern}" in "${path}" dir`),
-        options
+    if (options.files) {
+      options.debug && debug(
+        'using explicit list of `.env*` files: %s…',
+        options.files.join(', ')
       );
+
+      filenames = options.files
+        .reduce((list, basename) => {
+          const filename = p.resolve(path, basename);
+
+          if (fs.existsSync(filename)) {
+            list.push(filename);
+          }
+          else if (options.debug) {
+            debug('>> %s does not exist, skipping…', filename);
+          }
+
+          return list;
+        }, []);
+    }
+    else {
+      const node_env = getEffectiveNodeEnv(options);
+
+      filenames = listFiles({ node_env, path, pattern, debug: options.debug });
+
+      if (filenames.length === 0) {
+        const _pattern = node_env
+          ? pattern.replace(NODE_ENV_PLACEHOLDER_REGEX, `[$1${node_env}$2]`)
+          : pattern;
+
+        return failure(
+          new Error(`no ".env*" files matching pattern "${_pattern}" in "${path}" dir`),
+          options
+        );
+      }
     }
 
     const result = load(filenames, {

--- a/test/types/dotenv-flow.ts
+++ b/test/types/dotenv-flow.ts
@@ -84,6 +84,7 @@ dotenvFlow.config({ node_env: 'production' });
 dotenvFlow.config({ default_node_env: 'development' });
 dotenvFlow.config({ path: '/path/to/project' });
 dotenvFlow.config({ pattern: '.env[.node_env][.local]' });
+dotenvFlow.config({ files: ['.env', '.env.local'] });
 dotenvFlow.config({ encoding: 'utf8' });
 dotenvFlow.config({ purge_dotenv: true });
 dotenvFlow.config({ debug: true });
@@ -93,6 +94,7 @@ dotenvFlow.config({
   default_node_env: 'development',
   path: '/path/to/project',
   pattern: '.env[.node_env][.local]',
+  files: ['.env', '.env.local'],
   encoding: 'utf8',
   purge_dotenv: true,
   debug: true,


### PR DESCRIPTION
This CR adds the `files` option which allows explicitly specifying a list (and the order) of `.env*` files to load.