### PR TITLE
Add `types` fields to exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+### Bug Fixes
+
+* **dotenv-flow:** when used in TypeScript, `"moduleResolution": "bundler"` (and `"node16"` and `"nodenext"`) should now work, closes [#96](https://github.com/kerimdzhanov/dotenv-flow/issues/96)
+
 # [4.1.0](https://github.com/kerimdzhanov/dotenv-flow/compare/v4.0.1...v4.1.0) (2023-12-26)
 
 

--- a/package.json
+++ b/package.json
@@ -24,8 +24,12 @@
   "main": "lib/dotenv-flow.js",
   "types": "lib/dotenv-flow.d.ts",
   "exports": {
-    ".": "./lib/dotenv-flow.js",
+    ".": {
+      "types": "./lib/dotenv-flow.d.ts",
+      "default": "./lib/dotenv-flow.js"
+    },
     "./config": {
+      "types": "./config.d.ts",
       "require": "./config.js",
       "node": "./config.js"
     },


### PR DESCRIPTION
TypeScript 4.7 introduced `node16` and `nodenext` values for its `moduleResolution` setting, and version 5.0 introduced `bundler`. These mimic Node.js's module resolution and result in TypeScript looking at the `exports` keys in `package.json`. This is then also where it looks for `types`, rather than at the top level. Hence, this adds the relevant references to types there, to avoid errors like

    Type error: Cannot find module 'dotenv-flow/config' or its
    corresponding type declarations.

for importers of this library with that `moduleResolution` setting.

See https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing

Fixes #96.